### PR TITLE
Replace large-raster mode with split factor

### DIFF
--- a/coregix/cli/align_image_pair.py
+++ b/coregix/cli/align_image_pair.py
@@ -55,19 +55,13 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--large-raster-mode",
-        dest="large_raster_mode",
-        action="store_true",
+        "--split-factor",
+        type=int,
+        default=0,
         help=(
-            "Use the slower, lower-memory large-raster path with per-band "
-            "temporary TIFFs and subprocess-isolated transform application."
+            "Split the moving-overlap domain into 2^k chunks for chunked transform "
+            "application. 0=no split, 1=halves, 2=quadrants, 3=octants (default: 0)."
         ),
-    )
-    parser.add_argument(
-        "--use-disk-band-roundtrip",
-        dest="large_raster_mode",
-        action="store_true",
-        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--moving-nodata",
@@ -155,6 +149,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         parser.error("--min-valid-fraction must be in (0, 1].")
     if args.solve_resolution is not None and args.solve_resolution <= 0:
         parser.error("--solve-resolution must be > 0.")
+    if args.split_factor < 0:
+        parser.error("--split-factor must be >= 0.")
 
     result = align_image_pair(
         moving_image_path=args.moving_image,
@@ -175,7 +171,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         output_on_moving_grid=args.output_on_moving_grid,
         enforce_mutual_valid_mask=args.enforce_mutual_valid_mask,
         use_edge_proxies=args.use_edge_proxies,
-        large_raster_mode=args.large_raster_mode,
+        split_factor=args.split_factor,
         solve_resolution=args.solve_resolution,
     )
 

--- a/coregix/pipelines/alignment.py
+++ b/coregix/pipelines/alignment.py
@@ -16,10 +16,8 @@ from rasterio.windows import Window, from_bounds
 
 from coregix.preprocess.registration import (
     apply_elastix_transform_array,
-    apply_elastix_transform_subprocess,
     deformation_field_from_transform,
     estimate_elastix_transform,
-    write_transform_parameter_files,
 )
 
 DEFAULT_ALIGNMENT_PARAMETER_MAPS = ["translation", "rigid"]
@@ -166,369 +164,6 @@ def _edge_proxy(data: np.ndarray, valid_mask: np.ndarray) -> np.ndarray:
     return edge.astype(np.float32)
 
 
-def _align_image_pair_large_raster_main(
-    moving_image_path: str,
-    fixed_image_path: str,
-    output_image_path: str,
-    *,
-    band_index: int = 0,
-    moving_band_index: Optional[int] = None,
-    fixed_band_index: Optional[int] = None,
-    parameter_file_paths: Optional[List[str]] = None,
-    moving_nodata: Optional[float] = None,
-    fixed_nodata: Optional[float] = None,
-    output_nodata: Optional[float] = None,
-    min_valid_fraction: float = 0.01,
-    temp_dir: Optional[str] = None,
-    keep_temp_dir: bool = False,
-    log_to_console: bool = False,
-    clip_fixed_to_moving: bool = False,
-    output_on_moving_grid: bool = True,
-    enforce_mutual_valid_mask: bool = False,
-    use_edge_proxies: bool = True,
-) -> AlignmentResult:
-    """Large-raster execution path copied from main."""
-    temp_ctx = None
-    work_dir: str
-    if keep_temp_dir:
-        work_dir = tempfile.mkdtemp(prefix="vhr_align_", dir=temp_dir)
-    else:
-        temp_ctx = tempfile.TemporaryDirectory(prefix="vhr_align_", dir=temp_dir)
-        work_dir = temp_ctx.name
-
-    with rasterio.open(fixed_image_path) as fixed_src, rasterio.open(moving_image_path) as moving_src:
-        moving_band_1based = (moving_band_index if moving_band_index is not None else band_index) + 1
-        fixed_band_1based = (fixed_band_index if fixed_band_index is not None else band_index) + 1
-        if fixed_band_1based > fixed_src.count:
-            raise ValueError(
-                f"Requested fixed band index={fixed_band_1based - 1}, but fixed image has {fixed_src.count} band(s)."
-            )
-        if moving_band_1based > moving_src.count:
-            raise ValueError(
-                f"Requested moving band index={moving_band_1based - 1}, but moving image has {moving_src.count} band(s)."
-            )
-        if fixed_src.crs is None or moving_src.crs is None:
-            raise ValueError("Both fixed and moving images must have CRS.")
-        if fixed_src.crs != moving_src.crs:
-            raise ValueError(
-                "Fixed and moving images must share the same CRS for tile-window extraction. "
-                f"fixed={fixed_src.crs}, moving={moving_src.crs}"
-            )
-
-        moving_nodata_value = _resolve_nodata(moving_src, moving_nodata)
-        fixed_nodata_value = _resolve_nodata(fixed_src, fixed_nodata)
-        out_nodata = (
-            output_nodata
-            if output_nodata is not None
-            else moving_nodata_value
-            if moving_nodata_value is not None
-            else fixed_nodata_value
-            if fixed_nodata_value is not None
-            else 0
-        )
-
-        if clip_fixed_to_moving:
-            fixed_domain_window = _to_int_window(
-                from_bounds(
-                    left=moving_src.bounds.left,
-                    bottom=moving_src.bounds.bottom,
-                    right=moving_src.bounds.right,
-                    top=moving_src.bounds.top,
-                    transform=fixed_src.transform,
-                ),
-                max_width=fixed_src.width,
-                max_height=fixed_src.height,
-            )
-            if fixed_domain_window.width <= 0 or fixed_domain_window.height <= 0:
-                raise ValueError("No overlap between moving-image bounds and fixed-image grid.")
-        else:
-            fixed_domain_window = Window(col_off=0, row_off=0, width=fixed_src.width, height=fixed_src.height)
-
-        os.makedirs(os.path.dirname(output_image_path) or ".", exist_ok=True)
-        if output_on_moving_grid:
-            out_profile = _make_output_profile(
-                moving_src.profile,
-                count=moving_src.count,
-                dtype=moving_src.dtypes[0],
-                nodata=out_nodata,
-            )
-        else:
-            out_profile = _make_output_profile(
-                fixed_src.profile,
-                count=moving_src.count,
-                dtype=moving_src.dtypes[0],
-                nodata=out_nodata,
-                width=int(fixed_domain_window.width),
-                height=int(fixed_domain_window.height),
-                transform=fixed_src.window_transform(fixed_domain_window),
-            )
-
-        fixed_window = fixed_domain_window
-        core_out_window = Window(
-            col_off=0,
-            row_off=0,
-            width=int(fixed_domain_window.width),
-            height=int(fixed_domain_window.height),
-        )
-        fixed_window_transform = fixed_src.window_transform(fixed_window)
-        fixed_bounds = fixed_src.window_bounds(fixed_window)
-        moving_window = _to_int_window(
-            from_bounds(
-                left=fixed_bounds[0],
-                bottom=fixed_bounds[1],
-                right=fixed_bounds[2],
-                top=fixed_bounds[3],
-                transform=moving_src.transform,
-            ),
-            max_width=moving_src.width,
-            max_height=moving_src.height,
-        )
-        if moving_window.width <= 0 or moving_window.height <= 0:
-            raise ValueError("No overlap between fixed-image ROI and moving-image grid.")
-        moving_window_transform = moving_src.window_transform(moving_window)
-
-        with rasterio.open(output_image_path, "w+", **out_profile) as out_dst:
-            try:
-                out_dst.colorinterp = moving_src.colorinterp
-            except Exception:
-                pass
-            try:
-                out_dst.scales = moving_src.scales
-                out_dst.offsets = moving_src.offsets
-            except Exception:
-                pass
-            for b in range(1, moving_src.count + 1):
-                desc = moving_src.descriptions[b - 1]
-                if desc:
-                    out_dst.set_band_description(b, desc)
-                band_tags = moving_src.tags(b).copy()
-                for k in list(band_tags.keys()):
-                    if k.upper().startswith("STATISTICS_"):
-                        band_tags.pop(k, None)
-                out_dst.update_tags(b, **band_tags)
-                out_dst.update_tags(
-                    b,
-                    STATISTICS_MINIMUM="",
-                    STATISTICS_MAXIMUM="",
-                    STATISTICS_MEAN="",
-                    STATISTICS_STDDEV="",
-                )
-
-            if output_on_moving_grid:
-                for b in range(1, moving_src.count + 1):
-                    for _, block_window in out_dst.block_windows(b):
-                        src_block = moving_src.read(b, window=block_window)
-                        out_dst.write(src_block.astype(out_profile["dtype"]), b, window=block_window)
-            else:
-                for b in range(1, moving_src.count + 1):
-                    for _, block_window in out_dst.block_windows(b):
-                        fill = np.full(
-                            (int(block_window.height), int(block_window.width)),
-                            out_nodata,
-                            dtype=out_profile["dtype"],
-                        )
-                        out_dst.write(fill, b, window=block_window)
-
-            fixed_band = fixed_src.read(fixed_band_1based, window=fixed_window)
-            moving_band = moving_src.read(moving_band_1based, window=moving_window)
-            fixed_valid = fixed_src.read_masks(fixed_band_1based, window=fixed_window) > 0
-            moving_valid = moving_src.read_masks(moving_band_1based, window=moving_window) > 0
-            if fixed_nodata_value is not None:
-                fixed_valid &= fixed_band != fixed_nodata_value
-            if moving_nodata_value is not None:
-                moving_valid &= moving_band != moving_nodata_value
-
-            moving_valid_reprojected = np.zeros(
-                (int(fixed_window.height), int(fixed_window.width)),
-                dtype=np.uint8,
-            )
-            reproject(
-                source=moving_valid.astype(np.uint8),
-                destination=moving_valid_reprojected,
-                src_transform=moving_window_transform,
-                src_crs=moving_src.crs,
-                dst_transform=fixed_window_transform,
-                dst_crs=fixed_src.crs,
-                src_nodata=0,
-                dst_nodata=0,
-                resampling=Resampling.nearest,
-            )
-
-            fixed_reg_data = fixed_band.astype(np.float32)
-            moving_on_fixed = np.full(
-                (int(fixed_window.height), int(fixed_window.width)),
-                moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                dtype=np.float32,
-            )
-            reproject(
-                source=moving_band.astype(np.float32),
-                destination=moving_on_fixed,
-                src_transform=moving_window_transform,
-                src_crs=moving_src.crs,
-                dst_transform=fixed_window_transform,
-                dst_crs=fixed_src.crs,
-                src_nodata=moving_nodata_value,
-                dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                resampling=Resampling.nearest,
-            )
-            moving_on_fixed_valid = moving_valid_reprojected > 0
-            if use_edge_proxies:
-                fixed_reg_data = _edge_proxy(fixed_reg_data, fixed_valid)
-                moving_reg_data = _edge_proxy(moving_on_fixed, moving_on_fixed_valid)
-                fixed_mask_for_elastix = (fixed_reg_data > 0).astype(np.uint8)
-                moving_mask_for_elastix = (moving_reg_data > 0).astype(np.uint8)
-            else:
-                moving_reg_data = moving_on_fixed
-                fixed_mask_for_elastix = fixed_valid.astype(np.uint8)
-                moving_mask_for_elastix = moving_on_fixed_valid.astype(np.uint8)
-            if enforce_mutual_valid_mask:
-                mutual = (fixed_mask_for_elastix > 0) & (moving_mask_for_elastix > 0)
-                fixed_mask_for_elastix = mutual.astype(np.uint8)
-                moving_mask_for_elastix = mutual.astype(np.uint8)
-
-            min_valid_pixels = int(max(1, min_valid_fraction * (fixed_window.width * fixed_window.height)))
-            if int(fixed_mask_for_elastix.sum()) < min_valid_pixels:
-                raise ValueError("Insufficient valid fixed-image support in the registration ROI.")
-            if int(moving_mask_for_elastix.sum()) < min_valid_pixels:
-                raise ValueError("Insufficient valid moving-image support in the registration ROI.")
-
-            fixed_reg_path = os.path.join(work_dir, "fixed_reg.tif")
-            moving_reg_path = os.path.join(work_dir, "moving_reg.tif")
-            fixed_mask_path = os.path.join(work_dir, "fixed_mask.tif")
-            moving_mask_path = os.path.join(work_dir, "moving_mask.tif")
-
-            _write_single_band_tif(
-                fixed_reg_path,
-                fixed_reg_data.astype("float32"),
-                crs=fixed_src.crs,
-                transform=fixed_window_transform,
-                dtype="float32",
-                nodata=fixed_nodata_value,
-            )
-            _write_single_band_tif(
-                moving_reg_path,
-                moving_reg_data.astype("float32"),
-                crs=fixed_src.crs,
-                transform=fixed_window_transform,
-                dtype="float32",
-                nodata=moving_nodata_value,
-            )
-            _write_single_band_tif(
-                fixed_mask_path,
-                fixed_mask_for_elastix.astype("uint8"),
-                crs=fixed_src.crs,
-                transform=fixed_window_transform,
-                dtype="uint8",
-                nodata=0,
-            )
-            _write_single_band_tif(
-                moving_mask_path,
-                moving_mask_for_elastix.astype("uint8"),
-                crs=fixed_src.crs,
-                transform=fixed_window_transform,
-                dtype="uint8",
-                nodata=0,
-            )
-
-            try:
-                transform_parameter_object = estimate_elastix_transform(
-                    fixed_image_path=fixed_reg_path,
-                    moving_image_path=moving_reg_path,
-                    parameter_map=DEFAULT_ALIGNMENT_PARAMETER_MAPS,
-                    parameter_file_paths=parameter_file_paths,
-                    force_nearest_resample=True,
-                    fixed_mask_path=fixed_mask_path,
-                    moving_mask_path=moving_mask_path,
-                    log_to_console=log_to_console,
-                )
-            except Exception as exc:
-                raise RuntimeError(f"Elastix registration failed: {exc}") from exc
-
-            for b in range(1, moving_src.count + 1):
-                moving_band_path = os.path.join(work_dir, f"moving_band_{b:03d}.tif")
-                _stream_reprojected_band_to_tif(
-                    moving_band_path,
-                    src=moving_src,
-                    band_index=b,
-                    dst_crs=fixed_src.crs,
-                    dst_transform=fixed_window_transform,
-                    dst_width=int(fixed_window.width),
-                    dst_height=int(fixed_window.height),
-                    src_nodata=moving_nodata_value,
-                    dst_fill_value=out_nodata,
-                    output_nodata=moving_nodata_value,
-                )
-                if b == 1:
-                    serialized_transform_files = write_transform_parameter_files(
-                        transform_parameter_object,
-                        os.path.join(work_dir, "transform"),
-                    )
-                transformed_band_path = os.path.join(work_dir, f"warped_band_{b:03d}.tif")
-                apply_elastix_transform_subprocess(
-                    moving_image_path=moving_band_path,
-                    output_image_path=transformed_band_path,
-                    parameter_files=serialized_transform_files,
-                    reference_image_path=fixed_reg_path,
-                    log_to_console=log_to_console,
-                )
-                with rasterio.open(transformed_band_path) as warped_src:
-                    if output_on_moving_grid:
-                        src_transform = warped_src.transform
-                        src_crs = warped_src.crs or fixed_src.crs
-                        aligned_window_transform = moving_window_transform
-                        block_width, block_height = out_dst.block_shapes[b - 1]
-                        for row_off in range(0, int(moving_window.height), int(block_height)):
-                            for col_off in range(0, int(moving_window.width), int(block_width)):
-                                win_w = min(int(block_width), int(moving_window.width) - col_off)
-                                win_h = min(int(block_height), int(moving_window.height) - row_off)
-                                block_window = Window(col_off=col_off, row_off=row_off, width=win_w, height=win_h)
-                                remapped_block = np.full((win_h, win_w), out_nodata, dtype=np.float32)
-                                reproject(
-                                    source=rasterio.band(warped_src, 1),
-                                    destination=remapped_block,
-                                    src_transform=src_transform,
-                                    src_crs=src_crs,
-                                    src_nodata=out_nodata,
-                                    dst_transform=rasterio.windows.transform(block_window, aligned_window_transform),
-                                    dst_crs=moving_src.crs,
-                                    dst_nodata=out_nodata,
-                                    resampling=Resampling.bilinear,
-                                )
-                                source_block_window = Window(
-                                    col_off=int(moving_window.col_off + col_off),
-                                    row_off=int(moving_window.row_off + row_off),
-                                    width=win_w,
-                                    height=win_h,
-                                )
-                                existing_block = moving_src.read(b, window=source_block_window).astype(np.float32)
-                                valid = remapped_block != out_nodata
-                                combined = np.where(valid, remapped_block, existing_block)
-                                out_dst.write(
-                                    combined.astype(out_profile["dtype"]),
-                                    b,
-                                    window=source_block_window,
-                                )
-                    else:
-                        for _, block_window in warped_src.block_windows(1):
-                            block = warped_src.read(1, window=block_window)
-                            out_dst.write(
-                                block.astype(out_profile["dtype"]),
-                                b,
-                                window=block_window,
-                            )
-
-    if temp_ctx is not None:
-        temp_ctx.cleanup()
-        kept_temp = None
-    else:
-        kept_temp = work_dir
-
-    return AlignmentResult(
-        output_image_path=output_image_path,
-        temp_dir=kept_temp,
-    )
-
-
 def _sample_bilinear(
     data: np.ndarray,
     row_coords: np.ndarray,
@@ -638,7 +273,7 @@ def align_image_pair(
     output_on_moving_grid: bool = True,
     enforce_mutual_valid_mask: bool = False,
     use_edge_proxies: bool = True,
-    large_raster_mode: bool = False,
+    split_factor: int = 0,
     solve_resolution: Optional[float] = None,
 ) -> AlignmentResult:
     """Align a moving image onto a fixed image using the core elastix workflow.
@@ -671,9 +306,8 @@ def align_image_pair(
             elastix masks to the mutual valid-data overlap of both images.
         use_edge_proxies: If ``True``, register on edge-proxy images rather than
             raw intensities.
-        large_raster_mode: If ``True``, use the slower, lower-memory large-raster
-            path with per-band temporary TIFFs and subprocess-isolated transform
-            application.
+        split_factor: Split the moving-overlap domain into ``2**split_factor``
+            chunks for chunked transform application. ``0`` disables chunking.
         solve_resolution: Optional target pixel size, in raster CRS units, for the
             registration solve. When omitted, the fixed-image ROI resolution is used.
 
@@ -691,7 +325,9 @@ def align_image_pair(
         raise ValueError("fixed_band_index must be >= 0 (0-based).")
     if min_valid_fraction <= 0 or min_valid_fraction > 1:
         raise ValueError("min_valid_fraction must be in (0, 1].")
-    if large_raster_mode:
+    if split_factor < 0:
+        raise ValueError("split_factor must be >= 0.")
+    if split_factor > 0:
         from coregix.pipelines.alignment_large_main import (
             align_image_pair as align_image_pair_large_main,
         )
@@ -715,6 +351,7 @@ def align_image_pair(
             output_on_moving_grid=output_on_moving_grid,
             enforce_mutual_valid_mask=enforce_mutual_valid_mask,
             use_edge_proxies=use_edge_proxies,
+            split_factor=split_factor,
         )
     if solve_resolution is not None and solve_resolution <= 0:
         raise ValueError("solve_resolution must be > 0 when provided.")
@@ -821,17 +458,12 @@ def align_image_pair(
         if moving_window.width <= 0 or moving_window.height <= 0:
             raise ValueError("No overlap between fixed-image ROI and moving-image grid.")
         moving_window_transform = moving_src.window_transform(moving_window)
-        if large_raster_mode:
-            solve_width = int(fixed_window.width)
-            solve_height = int(fixed_window.height)
-            solve_transform = fixed_window_transform
-        else:
-            solve_width, solve_height, solve_transform = _resolve_solve_grid(
-                base_transform=fixed_window_transform,
-                base_width=int(fixed_window.width),
-                base_height=int(fixed_window.height),
-                solve_resolution=solve_resolution,
-            )
+        solve_width, solve_height, solve_transform = _resolve_solve_grid(
+            base_transform=fixed_window_transform,
+            base_width=int(fixed_window.width),
+            base_height=int(fixed_window.height),
+            solve_resolution=solve_resolution,
+        )
 
         with rasterio.open(output_image_path, "w+", **out_profile) as out_dst:
             # Preserve radiometric/band metadata from moving image and clear stale stats
@@ -889,104 +521,66 @@ def align_image_pair(
             if moving_nodata_value is not None:
                 moving_valid &= moving_band != moving_nodata_value
 
-            if large_raster_mode:
-                moving_valid_reprojected = np.zeros(
-                    (int(fixed_window.height), int(fixed_window.width)),
-                    dtype=np.uint8,
-                )
-                reproject(
-                    source=moving_valid.astype(np.uint8),
-                    destination=moving_valid_reprojected,
-                    src_transform=moving_window_transform,
-                    src_crs=moving_src.crs,
-                    dst_transform=fixed_window_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=0,
-                    dst_nodata=0,
-                    resampling=Resampling.nearest,
-                )
-                fixed_reg_data = fixed_band.astype(np.float32)
-                moving_mask_for_elastix: np.ndarray
-                fixed_mask_for_elastix: np.ndarray
-                moving_on_fixed = np.full(
-                    (int(fixed_window.height), int(fixed_window.width)),
-                    moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                    dtype=np.float32,
-                )
-                reproject(
-                    source=moving_band.astype(np.float32),
-                    destination=moving_on_fixed,
-                    src_transform=moving_window_transform,
-                    src_crs=moving_src.crs,
-                    dst_transform=fixed_window_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=moving_nodata_value,
-                    dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                    resampling=Resampling.nearest,
-                )
-                moving_on_fixed_valid = moving_valid_reprojected > 0
-                fixed_valid_for_registration = fixed_valid
-            else:
-                fixed_reg_data = np.full(
-                    (int(solve_height), int(solve_width)),
-                    fixed_nodata_value if fixed_nodata_value is not None else out_nodata,
-                    dtype=np.float32,
-                )
-                reproject(
-                    source=fixed_band.astype(np.float32),
-                    destination=fixed_reg_data,
-                    src_transform=fixed_window_transform,
-                    src_crs=fixed_src.crs,
-                    dst_transform=solve_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=fixed_nodata_value,
-                    dst_nodata=fixed_nodata_value if fixed_nodata_value is not None else out_nodata,
-                    resampling=Resampling.nearest,
-                )
-                fixed_valid_reprojected = np.zeros((int(solve_height), int(solve_width)), dtype=np.uint8)
-                reproject(
-                    source=fixed_valid.astype(np.uint8),
-                    destination=fixed_valid_reprojected,
-                    src_transform=fixed_window_transform,
-                    src_crs=fixed_src.crs,
-                    dst_transform=solve_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=0,
-                    dst_nodata=0,
-                    resampling=Resampling.nearest,
-                )
-                moving_valid_reprojected = np.zeros((int(solve_height), int(solve_width)), dtype=np.uint8)
-                reproject(
-                    source=moving_valid.astype(np.uint8),
-                    destination=moving_valid_reprojected,
-                    src_transform=moving_window_transform,
-                    src_crs=moving_src.crs,
-                    dst_transform=solve_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=0,
-                    dst_nodata=0,
-                    resampling=Resampling.nearest,
-                )
-                moving_mask_for_elastix: np.ndarray
-                fixed_mask_for_elastix: np.ndarray
-                moving_on_fixed = np.full(
-                    (int(solve_height), int(solve_width)),
-                    moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                    dtype=np.float32,
-                )
-                reproject(
-                    source=moving_band.astype(np.float32),
-                    destination=moving_on_fixed,
-                    src_transform=moving_window_transform,
-                    src_crs=moving_src.crs,
-                    dst_transform=solve_transform,
-                    dst_crs=fixed_src.crs,
-                    src_nodata=moving_nodata_value,
-                    dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
-                    resampling=Resampling.nearest,
-                )
-                moving_on_fixed_valid = moving_valid_reprojected > 0
-                fixed_valid_for_registration = fixed_valid_reprojected > 0
+            fixed_reg_data = np.full(
+                (int(solve_height), int(solve_width)),
+                fixed_nodata_value if fixed_nodata_value is not None else out_nodata,
+                dtype=np.float32,
+            )
+            reproject(
+                source=fixed_band.astype(np.float32),
+                destination=fixed_reg_data,
+                src_transform=fixed_window_transform,
+                src_crs=fixed_src.crs,
+                dst_transform=solve_transform,
+                dst_crs=fixed_src.crs,
+                src_nodata=fixed_nodata_value,
+                dst_nodata=fixed_nodata_value if fixed_nodata_value is not None else out_nodata,
+                resampling=Resampling.nearest,
+            )
+            fixed_valid_reprojected = np.zeros((int(solve_height), int(solve_width)), dtype=np.uint8)
+            reproject(
+                source=fixed_valid.astype(np.uint8),
+                destination=fixed_valid_reprojected,
+                src_transform=fixed_window_transform,
+                src_crs=fixed_src.crs,
+                dst_transform=solve_transform,
+                dst_crs=fixed_src.crs,
+                src_nodata=0,
+                dst_nodata=0,
+                resampling=Resampling.nearest,
+            )
+            moving_valid_reprojected = np.zeros((int(solve_height), int(solve_width)), dtype=np.uint8)
+            reproject(
+                source=moving_valid.astype(np.uint8),
+                destination=moving_valid_reprojected,
+                src_transform=moving_window_transform,
+                src_crs=moving_src.crs,
+                dst_transform=solve_transform,
+                dst_crs=fixed_src.crs,
+                src_nodata=0,
+                dst_nodata=0,
+                resampling=Resampling.nearest,
+            )
+            moving_mask_for_elastix: np.ndarray
+            fixed_mask_for_elastix: np.ndarray
+            moving_on_fixed = np.full(
+                (int(solve_height), int(solve_width)),
+                moving_nodata_value if moving_nodata_value is not None else out_nodata,
+                dtype=np.float32,
+            )
+            reproject(
+                source=moving_band.astype(np.float32),
+                destination=moving_on_fixed,
+                src_transform=moving_window_transform,
+                src_crs=moving_src.crs,
+                dst_transform=solve_transform,
+                dst_crs=fixed_src.crs,
+                src_nodata=moving_nodata_value,
+                dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
+                resampling=Resampling.nearest,
+            )
+            moving_on_fixed_valid = moving_valid_reprojected > 0
+            fixed_valid_for_registration = fixed_valid_reprojected > 0
             if use_edge_proxies:
                 fixed_reg_data = _edge_proxy(fixed_reg_data, fixed_valid_for_registration)
                 moving_reg_data = _edge_proxy(moving_on_fixed, moving_on_fixed_valid)
@@ -1001,10 +595,7 @@ def align_image_pair(
                 fixed_mask_for_elastix = mutual.astype(np.uint8)
                 moving_mask_for_elastix = mutual.astype(np.uint8)
 
-            if large_raster_mode:
-                min_valid_pixels = int(max(1, min_valid_fraction * (fixed_window.width * fixed_window.height)))
-            else:
-                min_valid_pixels = int(max(1, min_valid_fraction * (solve_width * solve_height)))
+            min_valid_pixels = int(max(1, min_valid_fraction * (solve_width * solve_height)))
             if int(fixed_mask_for_elastix.sum()) < min_valid_pixels:
                 raise ValueError("Insufficient valid fixed-image support in the registration ROI.")
             if int(moving_mask_for_elastix.sum()) < min_valid_pixels:
@@ -1019,7 +610,7 @@ def align_image_pair(
                 fixed_reg_path,
                 fixed_reg_data.astype("float32"),
                 crs=fixed_src.crs,
-                transform=fixed_window_transform if large_raster_mode else solve_transform,
+                transform=solve_transform,
                 dtype="float32",
                 nodata=fixed_nodata_value,
             )
@@ -1027,7 +618,7 @@ def align_image_pair(
                 moving_reg_path,
                 moving_reg_data.astype("float32"),
                 crs=fixed_src.crs,
-                transform=fixed_window_transform if large_raster_mode else solve_transform,
+                transform=solve_transform,
                 dtype="float32",
                 nodata=moving_nodata_value,
             )
@@ -1035,7 +626,7 @@ def align_image_pair(
                 fixed_mask_path,
                 fixed_mask_for_elastix.astype("uint8"),
                 crs=fixed_src.crs,
-                transform=fixed_window_transform if large_raster_mode else solve_transform,
+                transform=solve_transform,
                 dtype="uint8",
                 nodata=0,
             )
@@ -1043,7 +634,7 @@ def align_image_pair(
                 moving_mask_path,
                 moving_mask_for_elastix.astype("uint8"),
                 crs=fixed_src.crs,
-                transform=fixed_window_transform if large_raster_mode else solve_transform,
+                transform=solve_transform,
                 dtype="uint8",
                 nodata=0,
             )
@@ -1062,7 +653,7 @@ def align_image_pair(
             except Exception as exc:
                 raise RuntimeError(f"Elastix registration failed: {exc}") from exc
 
-            if output_on_moving_grid and not large_raster_mode:
+            if output_on_moving_grid:
                 deformation_field = deformation_field_from_transform(
                     fixed_reg_path,
                     transform_parameter_object,
@@ -1072,197 +663,117 @@ def align_image_pair(
                 fixed_dy = deformation_field[..., 1]
 
             for b in range(1, moving_src.count + 1):
-                if large_raster_mode:
-                    moving_band_path = os.path.join(work_dir, f"moving_band_{b:03d}.tif")
-                    _stream_reprojected_band_to_tif(
-                        moving_band_path,
-                        src=moving_src,
-                        band_index=b,
-                        dst_crs=fixed_src.crs,
-                        dst_transform=fixed_window_transform,
-                        dst_width=int(fixed_window.width),
-                        dst_height=int(fixed_window.height),
-                        src_nodata=moving_nodata_value,
-                        dst_fill_value=out_nodata,
-                        output_nodata=moving_nodata_value,
+                moving_band_data = moving_src.read(b, window=moving_window).astype(np.float32)
+                if output_on_moving_grid:
+                    moving_band_valid = moving_src.read_masks(b, window=moving_window).astype(np.float32)
+                    if moving_nodata_value is not None:
+                        moving_band_valid *= (moving_band_data != moving_nodata_value).astype(np.float32)
+                    block_width, block_height = out_dst.block_shapes[b - 1]
+                    for row_off in range(0, int(moving_window.height), int(block_height)):
+                        for col_off in range(0, int(moving_window.width), int(block_width)):
+                            win_w = min(int(block_width), int(moving_window.width) - col_off)
+                            win_h = min(int(block_height), int(moving_window.height) - row_off)
+                            block_window = Window(col_off=col_off, row_off=row_off, width=win_w, height=win_h)
+                            block_transform = rasterio.windows.transform(block_window, moving_window_transform)
+                            x_world, y_world = _pixel_centers_world(block_transform, win_h, win_w)
+                            solve_rows, solve_cols = _world_to_array_coords(
+                                solve_transform,
+                                x_world,
+                                y_world,
+                            )
+                            dx_block, dx_valid = _sample_bilinear(
+                                fixed_dx,
+                                solve_rows,
+                                solve_cols,
+                                fill_value=0.0,
+                            )
+                            dy_block, dy_valid = _sample_bilinear(
+                                fixed_dy,
+                                solve_rows,
+                                solve_cols,
+                                fill_value=0.0,
+                            )
+                            field_valid = dx_valid & dy_valid
+                            source_solve_rows = solve_rows + dy_block
+                            source_solve_cols = solve_cols + dx_block
+                            source_x_world, source_y_world = _array_to_world(
+                                solve_transform,
+                                source_solve_rows,
+                                source_solve_cols,
+                            )
+                            source_moving_rows, source_moving_cols = _world_to_array_coords(
+                                moving_window_transform,
+                                source_x_world,
+                                source_y_world,
+                            )
+                            remapped_block, moving_valid = _sample_bilinear(
+                                moving_band_data,
+                                source_moving_rows,
+                                source_moving_cols,
+                                fill_value=out_nodata,
+                            )
+                            sampled_mask, mask_valid = _sample_bilinear(
+                                moving_band_valid,
+                                source_moving_rows,
+                                source_moving_cols,
+                                fill_value=0.0,
+                            )
+                            source_block_window = Window(
+                                col_off=int(moving_window.col_off + col_off),
+                                row_off=int(moving_window.row_off + row_off),
+                                width=win_w,
+                                height=win_h,
+                            )
+                            valid = field_valid & moving_valid & mask_valid & (sampled_mask > 0.0)
+                            combined = np.where(valid, remapped_block, out_nodata)
+                            out_dst.write(
+                                combined.astype(out_profile["dtype"]),
+                                b,
+                                window=source_block_window,
+                            )
+                else:
+                    # Non-moving-grid output uses the solve grid, then remaps to fixed output grid.
+                    moving_band_on_fixed = np.full(
+                        (int(solve_height), int(solve_width)),
+                        out_nodata,
+                        dtype=np.float32,
                     )
-                    if b == 1:
-                        serialized_transform_files = write_transform_parameter_files(
-                            transform_parameter_object,
-                            os.path.join(work_dir, "transform"),
-                        )
-                    transformed_band_path = os.path.join(work_dir, f"warped_band_{b:03d}.tif")
-                    apply_elastix_transform_subprocess(
-                        moving_image_path=moving_band_path,
-                        output_image_path=transformed_band_path,
-                        parameter_files=serialized_transform_files,
-                        reference_image_path=fixed_reg_path,
+                    reproject(
+                        source=moving_band_data,
+                        destination=moving_band_on_fixed,
+                        src_transform=moving_window_transform,
+                        src_crs=moving_src.crs,
+                        dst_transform=solve_transform,
+                        dst_crs=fixed_src.crs,
+                        src_nodata=moving_nodata_value,
+                        dst_nodata=out_nodata,
+                        resampling=Resampling.nearest,
+                    )
+                    warped_full = apply_elastix_transform_array(
+                        moving_image=moving_band_on_fixed,
+                        transform_parameter_object=transform_parameter_object,
                         log_to_console=log_to_console,
                     )
-                    with rasterio.open(transformed_band_path) as warped_src:
-                        if output_on_moving_grid:
-                            src_transform = warped_src.transform
-                            src_crs = warped_src.crs or fixed_src.crs
-                            aligned_window_transform = moving_window_transform
-                            block_width, block_height = out_dst.block_shapes[b - 1]
-                            for row_off in range(0, int(moving_window.height), int(block_height)):
-                                for col_off in range(0, int(moving_window.width), int(block_width)):
-                                    win_w = min(int(block_width), int(moving_window.width) - col_off)
-                                    win_h = min(int(block_height), int(moving_window.height) - row_off)
-                                    block_window = Window(col_off=col_off, row_off=row_off, width=win_w, height=win_h)
-                                    remapped_block = np.full(
-                                        (win_h, win_w),
-                                        out_nodata,
-                                        dtype=np.float32,
-                                    )
-                                    reproject(
-                                        source=rasterio.band(warped_src, 1),
-                                        destination=remapped_block,
-                                        src_transform=src_transform,
-                                        src_crs=src_crs,
-                                        src_nodata=out_nodata,
-                                        dst_transform=rasterio.windows.transform(block_window, aligned_window_transform),
-                                        dst_crs=moving_src.crs,
-                                        dst_nodata=out_nodata,
-                                        resampling=Resampling.bilinear,
-                                    )
-                                    source_block_window = Window(
-                                        col_off=int(moving_window.col_off + col_off),
-                                        row_off=int(moving_window.row_off + row_off),
-                                        width=win_w,
-                                        height=win_h,
-                                    )
-                                    existing_block = moving_src.read(
-                                        b,
-                                        window=source_block_window,
-                                    ).astype(np.float32)
-                                    valid = remapped_block != out_nodata
-                                    combined = np.where(valid, remapped_block, existing_block)
-                                    out_dst.write(
-                                        combined.astype(out_profile["dtype"]),
-                                        b,
-                                        window=source_block_window,
-                                    )
-                        else:
-                            for _, block_window in warped_src.block_windows(1):
-                                block = warped_src.read(1, window=block_window)
-                                out_dst.write(
-                                    block.astype(out_profile["dtype"]),
-                                    b,
-                                    window=block_window,
-                                )
-                else:
-                    moving_band_data = moving_src.read(b, window=moving_window).astype(np.float32)
-                    if output_on_moving_grid:
-                        moving_band_valid = moving_src.read_masks(b, window=moving_window).astype(np.float32)
-                        if moving_nodata_value is not None:
-                            moving_band_valid *= (moving_band_data != moving_nodata_value).astype(np.float32)
-                        block_width, block_height = out_dst.block_shapes[b - 1]
-                        for row_off in range(0, int(moving_window.height), int(block_height)):
-                            for col_off in range(0, int(moving_window.width), int(block_width)):
-                                win_w = min(int(block_width), int(moving_window.width) - col_off)
-                                win_h = min(int(block_height), int(moving_window.height) - row_off)
-                                block_window = Window(col_off=col_off, row_off=row_off, width=win_w, height=win_h)
-                                block_transform = rasterio.windows.transform(block_window, moving_window_transform)
-                                x_world, y_world = _pixel_centers_world(block_transform, win_h, win_w)
-                                solve_rows, solve_cols = _world_to_array_coords(
-                                    solve_transform,
-                                    x_world,
-                                    y_world,
-                                )
-                                dx_block, dx_valid = _sample_bilinear(
-                                    fixed_dx,
-                                    solve_rows,
-                                    solve_cols,
-                                    fill_value=0.0,
-                                )
-                                dy_block, dy_valid = _sample_bilinear(
-                                    fixed_dy,
-                                    solve_rows,
-                                    solve_cols,
-                                    fill_value=0.0,
-                                )
-                                field_valid = dx_valid & dy_valid
-                                source_solve_rows = solve_rows + dy_block
-                                source_solve_cols = solve_cols + dx_block
-                                source_x_world, source_y_world = _array_to_world(
-                                    solve_transform,
-                                    source_solve_rows,
-                                    source_solve_cols,
-                                )
-                                source_moving_rows, source_moving_cols = _world_to_array_coords(
-                                    moving_window_transform,
-                                    source_x_world,
-                                    source_y_world,
-                                )
-                                remapped_block, moving_valid = _sample_bilinear(
-                                    moving_band_data,
-                                    source_moving_rows,
-                                    source_moving_cols,
-                                    fill_value=out_nodata,
-                                )
-                                sampled_mask, mask_valid = _sample_bilinear(
-                                    moving_band_valid,
-                                    source_moving_rows,
-                                    source_moving_cols,
-                                    fill_value=0.0,
-                                )
-                                source_block_window = Window(
-                                    col_off=int(moving_window.col_off + col_off),
-                                    row_off=int(moving_window.row_off + row_off),
-                                    width=win_w,
-                                    height=win_h,
-                                )
-                                valid = field_valid & moving_valid & mask_valid & (sampled_mask > 0.0)
-                                combined = np.where(valid, remapped_block, out_nodata)
-                                out_dst.write(
-                                    combined.astype(out_profile["dtype"]),
-                                    b,
-                                    window=source_block_window,
-                                )
+                    if solve_width == int(fixed_window.width) and solve_height == int(fixed_window.height):
+                        out_dst.write(warped_full.astype(out_profile["dtype"]), b, window=core_out_window)
                     else:
-                        # Non-moving-grid output uses the solve grid, then remaps to fixed output grid.
-                        moving_band_on_fixed = np.full(
-                            (int(solve_height), int(solve_width)),
+                        warped_on_fixed = np.full(
+                            (int(fixed_window.height), int(fixed_window.width)),
                             out_nodata,
                             dtype=np.float32,
                         )
                         reproject(
-                            source=moving_band_data,
-                            destination=moving_band_on_fixed,
-                            src_transform=moving_window_transform,
-                            src_crs=moving_src.crs,
-                            dst_transform=solve_transform,
+                            source=warped_full,
+                            destination=warped_on_fixed,
+                            src_transform=solve_transform,
+                            src_crs=fixed_src.crs,
+                            src_nodata=out_nodata,
+                            dst_transform=fixed_window_transform,
                             dst_crs=fixed_src.crs,
-                            src_nodata=moving_nodata_value,
                             dst_nodata=out_nodata,
-                            resampling=Resampling.nearest,
+                            resampling=Resampling.bilinear,
                         )
-                        warped_full = apply_elastix_transform_array(
-                            moving_image=moving_band_on_fixed,
-                            transform_parameter_object=transform_parameter_object,
-                            log_to_console=log_to_console,
-                        )
-                        if solve_width == int(fixed_window.width) and solve_height == int(fixed_window.height):
-                            out_dst.write(warped_full.astype(out_profile["dtype"]), b, window=core_out_window)
-                        else:
-                            warped_on_fixed = np.full(
-                                (int(fixed_window.height), int(fixed_window.width)),
-                                out_nodata,
-                                dtype=np.float32,
-                            )
-                            reproject(
-                                source=warped_full,
-                                destination=warped_on_fixed,
-                                src_transform=solve_transform,
-                                src_crs=fixed_src.crs,
-                                src_nodata=out_nodata,
-                                dst_transform=fixed_window_transform,
-                                dst_crs=fixed_src.crs,
-                                dst_nodata=out_nodata,
-                                resampling=Resampling.bilinear,
-                            )
-                            out_dst.write(warped_on_fixed.astype(out_profile["dtype"]), b, window=core_out_window)
+                        out_dst.write(warped_on_fixed.astype(out_profile["dtype"]), b, window=core_out_window)
 
     if temp_ctx is not None:
         temp_ctx.cleanup()

--- a/coregix/pipelines/alignment_large_main.py
+++ b/coregix/pipelines/alignment_large_main.py
@@ -1,4 +1,4 @@
-"""Pairwise alignment pipeline copied from main for large-raster mode."""
+"""Chunked pairwise alignment pipeline for split-factor execution."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from coregix.preprocess.registration import (
 )
 
 DEFAULT_ALIGNMENT_PARAMETER_MAPS = ["translation", "rigid"]
-LARGE_RASTER_QUADRANT_OVERLAP_PX = 256
+CHUNK_OVERLAP_PX = 256
 
 
 @dataclass
@@ -31,13 +31,11 @@ class AlignmentResult:
 
 
 @dataclass
-class QuadrantChunk:
+class RasterChunk:
     core_local_window: Window
     chunk_local_window: Window
-    core_source_window: Window
     chunk_source_window: Window
     chunk_transform: object
-    fixed_chunk_window: Window
     fixed_chunk_transform: object
     fixed_dx: np.ndarray
     fixed_dy: np.ndarray
@@ -244,6 +242,24 @@ def _expand_window(window: Window, overlap: int, max_width: int, max_height: int
     )
 
 
+def _split_positions(length: int, parts: int) -> list[int]:
+    if parts <= 0:
+        raise ValueError("parts must be > 0.")
+    return [int(i * length // parts) for i in range(parts + 1)]
+
+
+def _chunk_grid_shape(split_factor: int, width: int, height: int) -> tuple[int, int]:
+    if split_factor < 0:
+        raise ValueError("split_factor must be >= 0.")
+    if split_factor == 0:
+        return 1, 1
+    major_exp = (split_factor + 1) // 2
+    minor_exp = split_factor // 2
+    if width >= height:
+        return 2**minor_exp, 2**major_exp
+    return 2**major_exp, 2**minor_exp
+
+
 def align_image_pair(
     moving_image_path: str,
     fixed_image_path: str,
@@ -264,6 +280,7 @@ def align_image_pair(
     output_on_moving_grid: bool = True,
     enforce_mutual_valid_mask: bool = False,
     use_edge_proxies: bool = True,
+    split_factor: int = 2,
 ) -> AlignmentResult:
     if band_index < 0:
         raise ValueError("band_index must be >= 0 (0-based).")
@@ -273,6 +290,8 @@ def align_image_pair(
         raise ValueError("fixed_band_index must be >= 0 (0-based).")
     if min_valid_fraction <= 0 or min_valid_fraction > 1:
         raise ValueError("min_valid_fraction must be in (0, 1].")
+    if split_factor <= 0:
+        raise ValueError("split_factor must be > 0 for the chunked alignment path.")
 
     temp_ctx = None
     work_dir: str
@@ -531,14 +550,15 @@ def align_image_pair(
             except Exception as exc:
                 raise RuntimeError(f"Elastix registration failed: {exc}") from exc
 
-            quadrant_chunks: list[QuadrantChunk] = []
+            raster_chunks: list[RasterChunk] = []
             if output_on_moving_grid:
                 moving_h = int(moving_window.height)
                 moving_w = int(moving_window.width)
-                row_splits = [0, moving_h // 2, moving_h]
-                col_splits = [0, moving_w // 2, moving_w]
-                for row_idx in range(2):
-                    for col_idx in range(2):
+                n_rows, n_cols = _chunk_grid_shape(split_factor, moving_w, moving_h)
+                row_splits = _split_positions(moving_h, n_rows)
+                col_splits = _split_positions(moving_w, n_cols)
+                for row_idx in range(n_rows):
+                    for col_idx in range(n_cols):
                         core_local_window = Window(
                             col_off=col_splits[col_idx],
                             row_off=row_splits[row_idx],
@@ -549,7 +569,7 @@ def align_image_pair(
                             continue
                         chunk_local_window = _expand_window(
                             core_local_window,
-                            LARGE_RASTER_QUADRANT_OVERLAP_PX,
+                            CHUNK_OVERLAP_PX,
                             moving_w,
                             moving_h,
                         )
@@ -558,12 +578,6 @@ def align_image_pair(
                             row_off=int(moving_window.row_off + chunk_local_window.row_off),
                             width=int(chunk_local_window.width),
                             height=int(chunk_local_window.height),
-                        )
-                        core_source_window = Window(
-                            col_off=int(moving_window.col_off + core_local_window.col_off),
-                            row_off=int(moving_window.row_off + core_local_window.row_off),
-                            width=int(core_local_window.width),
-                            height=int(core_local_window.height),
                         )
                         chunk_transform = moving_src.window_transform(chunk_source_window)
                         chunk_bounds = rasterio.windows.bounds(
@@ -608,14 +622,12 @@ def align_image_pair(
                             transform_parameter_object,
                             output_directory=work_dir,
                         ).astype(np.float32)
-                        quadrant_chunks.append(
-                            QuadrantChunk(
+                        raster_chunks.append(
+                            RasterChunk(
                                 core_local_window=core_local_window,
                                 chunk_local_window=chunk_local_window,
-                                core_source_window=core_source_window,
                                 chunk_source_window=chunk_source_window,
                                 chunk_transform=chunk_transform,
-                                fixed_chunk_window=fixed_chunk_window,
                                 fixed_chunk_transform=fixed_chunk_transform,
                                 fixed_dx=deformation_field[..., 0],
                                 fixed_dy=deformation_field[..., 1],
@@ -624,7 +636,7 @@ def align_image_pair(
 
             for b in range(1, moving_src.count + 1):
                 if output_on_moving_grid:
-                    for chunk in quadrant_chunks:
+                    for chunk in raster_chunks:
                         moving_band_data = moving_src.read(b, window=chunk.chunk_source_window).astype(np.float32)
                         moving_band_valid = moving_src.read_masks(b, window=chunk.chunk_source_window).astype(np.float32)
                         if moving_nodata_value is not None:


### PR DESCRIPTION
## Summary

  Replace the dedicated large-raster mode with a general `split_factor` option for chunked transform application.

  `split_factor` controls the number of chunks as `2^k`:
  - `0`: no split
  - `1`: halves
  - `2`: quadrants
  - `3`: octants

  This keeps the existing chunked logic but removes the separate mode-specific API.

  ## Changes

  - add `--split-factor` to the alignment CLI
  - remove `--large-raster-mode`
  - dispatch chunked execution when `split_factor > 0`
  - generalize chunk creation from fixed quadrants to `2^k` chunks
  - remove dead large-raster helper code

  ## Validation

  - `py_compile` passed for the touched modules
  - smoke test succeeded with `--split-factor 0`
  - smoke test succeeded with `--split-factor 2`
  - split and non-split smoke outputs matched on size, geotransform, and checksums