### PR TITLE
Refactor file handling to use temporary paths before finalizing.

### DIFF
--- a/coregix/pipelines/alignment.py
+++ b/coregix/pipelines/alignment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass
 from typing import Optional
@@ -434,6 +435,7 @@ def align_image_pair(
             )
 
         os.makedirs(os.path.dirname(output_image_path) or ".", exist_ok=True)
+        temp_output_image_path = os.path.join(work_dir, os.path.basename(output_image_path))
         if output_on_moving_grid:
             out_profile = _make_output_profile(
                 moving_src.profile,
@@ -482,7 +484,7 @@ def align_image_pair(
             solve_resolution=solve_resolution,
         )
 
-        with rasterio.open(output_image_path, "w+", **out_profile) as out_dst:
+        with rasterio.open(temp_output_image_path, "w+", **out_profile) as out_dst:
             # Preserve radiometric/band metadata from moving image and clear stale stats
             # that can cause misleading display stretches in GIS viewers.
             try:
@@ -795,14 +797,16 @@ def align_image_pair(
             from coregix.postprocess import trim_edge_invalid_pixels
 
             trim_edge_invalid_pixels(
-                input_image_path=output_image_path,
-                in_place=True,
+                input_image_path=temp_output_image_path,
+                output_image_path=output_image_path,
                 edge_depth=edge_trim_depth,
                 detection_band_index=edge_trim_detection_band_index,
                 invalid_below=edge_trim_invalid_below,
                 invalid_above=edge_trim_invalid_above,
                 nodata_value=out_nodata,
             )
+        else:
+            shutil.copyfile(temp_output_image_path, output_image_path)
 
     if temp_ctx is not None:
         temp_ctx.cleanup()

--- a/coregix/pipelines/alignment_large_main.py
+++ b/coregix/pipelines/alignment_large_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass
 from typing import Optional
@@ -772,6 +773,7 @@ def align_image_pair(
         )
 
         os.makedirs(os.path.dirname(output_image_path) or ".", exist_ok=True)
+        temp_output_image_path = os.path.join(work_dir, os.path.basename(output_image_path))
         if output_on_moving_grid:
             out_profile = _make_output_profile(
                 moving_src.profile,
@@ -796,7 +798,7 @@ def align_image_pair(
             target_row_splits = _split_positions(int(fixed_window.height), target_rows)
             target_col_splits = _split_positions(int(fixed_window.width), target_cols)
 
-        with rasterio.open(output_image_path, "w+", **out_profile) as out_dst:
+        with rasterio.open(temp_output_image_path, "w+", **out_profile) as out_dst:
             try:
                 out_dst.colorinterp = moving_src.colorinterp
             except Exception:
@@ -942,14 +944,16 @@ def align_image_pair(
             from coregix.postprocess import trim_edge_invalid_pixels
 
             trim_edge_invalid_pixels(
-                input_image_path=output_image_path,
-                in_place=True,
+                input_image_path=temp_output_image_path,
+                output_image_path=output_image_path,
                 edge_depth=edge_trim_depth,
                 detection_band_index=edge_trim_detection_band_index,
                 invalid_below=edge_trim_invalid_below,
                 invalid_above=edge_trim_invalid_above,
                 nodata_value=out_nodata,
             )
+        else:
+            shutil.copyfile(temp_output_image_path, output_image_path)
 
     if temp_ctx is not None:
         temp_ctx.cleanup()

--- a/coregix/postprocess/edge_trim.py
+++ b/coregix/postprocess/edge_trim.py
@@ -148,10 +148,10 @@ def trim_edge_invalid_pixels(
 
     with tempfile.TemporaryDirectory(
         prefix="edge_trim_",
-        dir=os.path.dirname(final_path) or None,
+        dir=os.path.dirname(input_image_path) or None,
     ) as temp_dir:
         temp_output_path = os.path.join(temp_dir, os.path.basename(final_path))
-        shutil.copy2(input_image_path, temp_output_path)
+        shutil.copyfile(input_image_path, temp_output_path)
 
         pixels_trimmed = 0
         with rasterio.open(input_image_path) as src, rasterio.open(temp_output_path, "r+") as dst:
@@ -206,8 +206,10 @@ def trim_edge_invalid_pixels(
                     trim_mask=trim_mask,
                     nodata_value=resolved_nodata,
                 )
-
-        os.replace(temp_output_path, final_path)
+        if in_place:
+            os.replace(temp_output_path, final_path)
+        else:
+            shutil.copyfile(temp_output_path, final_path)
 
     return EdgeTrimResult(
         output_image_path=final_path,


### PR DESCRIPTION
Introduce temporary output paths to ensure atomic operations and avoid partial writes during alignment and edge trimming. Replace direct in-place modifications with shutil operations for improved file handling consistency.