### PR TITLE
Rename CLI command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN conda install -y -c conda-forge \
     && pip install --no-cache-dir . \
     && conda clean -afy
 
-ENTRYPOINT ["vhr-align-image-pair"]
+ENTRYPOINT ["align-image-pair"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install -e .
 The installed CLI entrypoint is:
 
 ```bash
-vhr-align-image-pair --help
+align-image-pair --help
 ```
 
 You can also run the module directly:
@@ -75,7 +75,7 @@ If you built the image locally, use `coregix` instead of `iosefa/coregix:latest`
 ### Coregister a source image to a reference image
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned.tif
@@ -97,7 +97,7 @@ By default this:
 Example with quadrants:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source_large.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned_large.tif \
@@ -111,7 +111,7 @@ vhr-align-image-pair \
 Example:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source_large.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned_large_edgefixed.tif \

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -31,7 +31,7 @@ Coregix does not perform CRS reprojection as a substitute for registration. If t
 Registration is estimated from one band in each raster. By default, Coregix uses band index `0` from both rasters. Separate source and reference registration bands can be selected when the strongest registration signal is not in the same band position.
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -50,7 +50,7 @@ Edge proxies are useful when the source and reference rasters represent similar 
 Use raw values instead with:
 
 ```bash
-vhr-align-image-pair ... --no-use-edge-proxies
+align-image-pair ... --no-use-edge-proxies
 ```
 
 or in Python:
@@ -66,7 +66,7 @@ Registration should be estimated from valid image support only. Coregix builds m
 Override nodata values when the raster metadata is missing or incorrect:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -83,7 +83,7 @@ Coregix estimates the transform on a solve grid derived from the reference raste
 `--solve-resolution` can be used to estimate the transform on a coarser grid, expressed in raster CRS units:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -105,7 +105,7 @@ Output nodata defaults to the source nodata value, then the reference nodata val
 By default, Coregix writes the result on the source-raster grid. This preserves the source raster's dimensions, transform, band count, and most band metadata, while replacing pixels in the registered overlap region.
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -115,7 +115,7 @@ vhr-align-image-pair \
 Write on the reference-raster grid with:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned_on_reference_grid.tif \
@@ -144,7 +144,7 @@ Use the smallest `split_factor` that keeps processing stable. Higher values incr
 Resampling can leave invalid border artifacts around nodata regions. `--trim-edge-invalid` applies a post-processing pass that detects invalid areas and expands them by a configurable number of pixels.
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned_trimmed.tif \

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Large rasters can be processed in chunks. Edge cleanup is available for outputs 
 Use `--moving-image` for the source raster and `--fixed-image` for the reference raster:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned.tif

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ For most users, installing from PyPI is the right starting point.
 pip install coregix
 ```
 
-This installs the Python API and the `vhr-align-image-pair` command-line entrypoint.
+This installs the Python API and the `align-image-pair` command-line entrypoint.
 
 ## Docker
 
@@ -48,14 +48,14 @@ docker run --rm \
 
 If you built the image locally, use `coregix` instead of `iosefa/coregix:latest`.
 
-The container entrypoint is `vhr-align-image-pair`, so any CLI option can be passed directly after the image name.
+The container entrypoint is `align-image-pair`, so any CLI option can be passed directly after the image name.
 
 ## Verify The Install
 
 Check the command-line entrypoint:
 
 ```bash
-vhr-align-image-pair --help
+align-image-pair --help
 ```
 
 You can also run the CLI module directly:

--- a/docs/usage/alignment.md
+++ b/docs/usage/alignment.md
@@ -10,7 +10,7 @@ The CLI keeps the registration library's argument names:
 ## Basic CLI Alignment
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned.tif
@@ -56,7 +56,7 @@ The CLI and Python API use the same registration defaults.
 Registration is estimated from one band in each raster. Use `--band-index` when the same 0-based band should be used from both rasters:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -66,7 +66,7 @@ vhr-align-image-pair \
 Use separate band indexes when the best registration signal is in different bands:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -93,7 +93,7 @@ All source bands are transformed after the registration model is estimated.
 The default output grid is the source-raster grid:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -105,7 +105,7 @@ Use this when the aligned raster needs to remain compatible with a source image 
 Write on the reference-raster grid with:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned_on_reference_grid.tif \
@@ -119,7 +119,7 @@ Use this when the output should match the reference raster's extent, transform, 
 Coregix reads raster masks and nodata metadata when building registration masks. If the source metadata is missing or incorrect, provide nodata values explicitly:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
@@ -135,7 +135,7 @@ vhr-align-image-pair \
 Temporary registration images and masks are normally deleted after the command finishes. Keep them when diagnosing a failed or unexpected registration:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \

--- a/docs/usage/edge-trimming.md
+++ b/docs/usage/edge-trimming.md
@@ -9,7 +9,7 @@ Use edge trimming when the aligned output contains narrow border artifacts near 
 Add `--trim-edge-invalid` to run cleanup after the coregistered output is written:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source_large.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned_trimmed.tif \

--- a/docs/usage/large-rasters.md
+++ b/docs/usage/large-rasters.md
@@ -9,7 +9,7 @@ Chunking is controlled with `--split-factor`. The total number of chunks is `2 *
 Start without chunking. Add `--split-factor` when memory use or runtime becomes impractical:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image /path/to/source_large.tif \
   --fixed-image /path/to/reference.tif \
   --output-image /path/to/aligned_large.tif \
@@ -49,7 +49,7 @@ Higher values create more chunks and more overhead. They can also fail if indivi
 For a projected CRS in meters, `--solve-resolution 2.0` uses an approximate 2-meter solve grid:
 
 ```bash
-vhr-align-image-pair \
+align-image-pair \
   --moving-image source_large.tif \
   --fixed-image reference.tif \
   --output-image aligned_large.tif \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ testpaths = ["tests"]
 "Source" = "https://github.com/iosefa/coregix"
 
 [project.scripts]
-vhr-align-image-pair = "coregix.cli.align_image_pair:main"
+align-image-pair = "coregix.cli.align_image_pair:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from coregix.cli import align_image_pair as align_cli
 from coregix.cli import trim_edge_invalid as trim_cli
+
+
+def test_console_script_name_has_no_legacy_vhr_prefix() -> None:
+    pyproject = Path("pyproject.toml").read_text()
+    legacy_command = "vhr" "-align-image-pair"
+
+    assert 'align-image-pair = "coregix.cli.align_image_pair:main"' in pyproject
+    assert legacy_command not in pyproject
 
 
 def test_align_parser_defaults_use_current_registration_policy() -> None:


### PR DESCRIPTION
## Summary

Renames the installed Coregix CLI command from `vhr-align-image-pair` to `align-image-pair`.

## Changes

  - Updates the console script entrypoint in `pyproject.toml`
  - Updates the Docker image entrypoint
  - Replaces CLI examples in the README and documentation
  - Adds a test to prevent the legacy `vhr-` command name from returning

## Rationale

The old command name implied a VHR-specific scope that is not required by the library. `align-image-pair` better matches the Python API and the package’s current documentation language.

## Validation

  - `pytest -q`
  - `conda run -n coregix mkdocs build --strict`