### PR TITLE
Release v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ coregix = ["py.typed"]
 
 [project]
 name = "coregix"
-version = "0.1.3"
+version = "0.2.0"
 description = "Pairwise raster coregistration for geospatial imagery"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Bumps the package version to 0.2.0 in preparation for the next release.

## Rationale

This release includes user-facing CLI changes, documentation, Docker publishing, and test coverage added since v0.1.3. The CLI command rename from vhr-align-image-pair to align-image-pair is a breaking command-line interface change, so this uses a minor version bump.

## Validation

- pytest -q
- python -m compileall -q coregix tests

Note: local package build was not run because the local environments do not currently have the build package installed; the PyPI workflow installs build during release.