### PR TITLE
Coarse to fine solve resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ align-image-pair \
   --split-factor 2
 ```
 
+### Use coarse-to-fine registration for large initial offsets
+
+`--solve-resolutions` runs multiple registration solves from coarse to fine,
+then writes the final raster once from the original source image. Use `0` for
+the reference-raster/native solve resolution.
+
+`--solve-resolution` is deprecated and remains available for single-pass
+compatibility. Prefer `--solve-resolutions`, even for one solve.
+
+```bash
+align-image-pair \
+  --moving-image /path/to/source_large.tif \
+  --fixed-image /path/to/reference.tif \
+  --output-image /path/to/aligned_large.tif \
+  --split-factor 2 \
+  --solve-resolutions 8,4,0.5
+```
+
 ### Remove invalid edge artifacts after alignment
 
 `--trim-edge-invalid` runs a raster-space cleanup pass after alignment and sets edge artifacts to nodata.

--- a/coregix/cli/align_image_pair.py
+++ b/coregix/cli/align_image_pair.py
@@ -10,6 +10,21 @@ from typing import Optional
 from coregix.pipelines.alignment import align_image_pair
 
 
+def _parse_solve_resolutions(value: str) -> list[Optional[float]]:
+    resolutions: list[Optional[float]] = []
+    for item in value.split(","):
+        text = item.strip()
+        if not text:
+            raise argparse.ArgumentTypeError("--solve-resolutions entries must not be empty.")
+        resolution = float(text)
+        if resolution < 0:
+            raise argparse.ArgumentTypeError("--solve-resolutions entries must be >= 0.")
+        resolutions.append(None if resolution == 0 else resolution)
+    if not resolutions:
+        raise argparse.ArgumentTypeError("--solve-resolutions must contain at least one entry.")
+    return resolutions
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build CLI parser for pairwise raster coregistration."""
     parser = argparse.ArgumentParser(
@@ -79,8 +94,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--solve-resolution",
         type=float,
         help=(
-            "Optional target pixel size, in raster CRS units, for the registration solve. "
-            "Defaults to the reference-raster ROI resolution."
+            "Deprecated single-pass target pixel size, in raster CRS units, for the "
+            "registration solve. Use --solve-resolutions with one or more values instead."
+        ),
+    )
+    parser.add_argument(
+        "--solve-resolutions",
+        type=_parse_solve_resolutions,
+        help=(
+            "Comma-separated coarse-to-fine solve pixel sizes, in raster CRS units. "
+            "Use 0 for native/reference resolution, for example 8,4,0.5 or 8,4,0."
         ),
     )
     parser.add_argument("--temp-dir", help="Optional parent directory for temporary working files.")
@@ -172,6 +195,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         parser.error("--fixed-band-index must be >= 0.")
     if args.min_valid_fraction <= 0 or args.min_valid_fraction > 1:
         parser.error("--min-valid-fraction must be in (0, 1].")
+    if args.solve_resolution is not None and args.solve_resolutions is not None:
+        parser.error("Provide only one of --solve-resolution or --solve-resolutions.")
     if args.solve_resolution is not None and args.solve_resolution <= 0:
         parser.error("--solve-resolution must be > 0.")
     if args.split_factor < 0:
@@ -206,6 +231,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         use_edge_proxies=args.use_edge_proxies,
         split_factor=args.split_factor,
         solve_resolution=args.solve_resolution,
+        solve_resolutions=args.solve_resolutions,
     )
 
     print(

--- a/coregix/pipelines/alignment.py
+++ b/coregix/pipelines/alignment.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 import rasterio
@@ -298,6 +298,7 @@ def align_image_pair(
     use_edge_proxies: bool = True,
     split_factor: int = 0,
     solve_resolution: Optional[float] = None,
+    solve_resolutions: Optional[Sequence[Optional[float]]] = None,
 ) -> AlignmentResult:
     """Coregister a source raster to a reference raster.
 
@@ -341,8 +342,14 @@ def align_image_pair(
             raw intensities.
         split_factor: Split the registration solve and final resampling domains
             into ``2**split_factor`` chunks. ``0`` disables chunking.
-        solve_resolution: Optional target pixel size, in raster CRS units, for the
-            registration solve. When omitted, the reference-raster ROI resolution is used.
+        solve_resolution: Deprecated optional target pixel size, in raster CRS units,
+            for a single-pass registration solve. Use ``solve_resolutions`` with one
+            or more values instead.
+        solve_resolutions: Optional coarse-to-fine sequence of solve pixel sizes.
+            Each pass refines the previous transform and the final output is
+            resampled once from the original source raster. ``None`` entries use
+            the reference-raster ROI resolution. Requires chunked alignment when
+            more than one resolution is provided.
 
     Returns:
         AlignmentResult summary with output path and retained temporary directory,
@@ -365,6 +372,18 @@ def align_image_pair(
         raise ValueError("edge_trim_depth must be > 0.")
     if edge_trim_detection_band_index < 0:
         raise ValueError("edge_trim_detection_band_index must be >= 0.")
+    if solve_resolution is not None and solve_resolutions is not None:
+        raise ValueError("Provide only one of solve_resolution or solve_resolutions.")
+    if solve_resolutions is not None:
+        if len(solve_resolutions) == 0:
+            raise ValueError("solve_resolutions must contain at least one entry.")
+        for resolution in solve_resolutions:
+            if resolution is not None and resolution <= 0:
+                raise ValueError("solve_resolutions entries must be > 0 or None.")
+        if split_factor == 0 and len(solve_resolutions) > 1:
+            raise ValueError("Multi-pass solve_resolutions requires split_factor > 0.")
+        if split_factor == 0:
+            solve_resolution = solve_resolutions[0]
     if split_factor > 0:
         from coregix.pipelines.alignment_large_main import (
             align_image_pair as align_image_pair_large_main,
@@ -395,6 +414,7 @@ def align_image_pair(
             use_edge_proxies=use_edge_proxies,
             split_factor=split_factor,
             solve_resolution=solve_resolution,
+            solve_resolutions=solve_resolutions,
         )
     if solve_resolution is not None and solve_resolution <= 0:
         raise ValueError("solve_resolution must be > 0 when provided.")

--- a/coregix/pipelines/alignment_large_main.py
+++ b/coregix/pipelines/alignment_large_main.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 import rasterio
@@ -34,6 +34,20 @@ class AlignmentResult:
 class GlobalRigidTransform:
     rotation: np.ndarray
     translation: np.ndarray
+
+
+def _identity_transform() -> GlobalRigidTransform:
+    return GlobalRigidTransform(
+        rotation=np.eye(2, dtype=np.float64),
+        translation=np.zeros(2, dtype=np.float64),
+    )
+
+
+def _is_identity_transform(transform: GlobalRigidTransform) -> bool:
+    return bool(
+        np.allclose(transform.rotation, np.eye(2, dtype=np.float64))
+        and np.allclose(transform.translation, np.zeros(2, dtype=np.float64))
+    )
 
 
 def _to_int_window(window: Window, max_width: int, max_height: int) -> Window:
@@ -388,6 +402,68 @@ def _source_window_for_target_window(
     return _expand_window(source_window, padding_pixels, moving_width, moving_height)
 
 
+def _sample_moving_band_on_solve_grid(
+    *,
+    moving_src: rasterio.DatasetReader,
+    moving_band_1based: int,
+    moving_nodata_value: Optional[float],
+    out_nodata: float,
+    chunk_solve_transform,
+    solve_width: int,
+    solve_height: int,
+    current_transform: GlobalRigidTransform,
+) -> tuple[np.ndarray, np.ndarray]:
+    target_window = Window(0, 0, solve_width, solve_height)
+    source_window = _source_window_for_target_window(
+        target_window,
+        chunk_solve_transform,
+        moving_src.transform,
+        current_transform,
+        moving_src.width,
+        moving_src.height,
+    )
+    moving_reg_data = np.full(
+        (solve_height, solve_width),
+        moving_nodata_value if moving_nodata_value is not None else out_nodata,
+        dtype=np.float32,
+    )
+    moving_valid_for_registration = np.zeros((solve_height, solve_width), dtype=bool)
+    if source_window.width <= 0 or source_window.height <= 0:
+        return moving_reg_data, moving_valid_for_registration
+
+    moving_band = moving_src.read(moving_band_1based, window=source_window).astype(np.float32)
+    moving_valid = moving_src.read_masks(moving_band_1based, window=source_window).astype(np.float32)
+    if moving_nodata_value is not None:
+        moving_valid *= (moving_band != moving_nodata_value).astype(np.float32)
+
+    x_world, y_world = _pixel_centers_world(chunk_solve_transform, solve_height, solve_width)
+    source_x_world, source_y_world = _apply_world_transform(
+        current_transform,
+        x_world,
+        y_world,
+    )
+    source_transform = moving_src.window_transform(source_window)
+    source_rows, source_cols = _world_to_array_coords(
+        source_transform,
+        source_x_world,
+        source_y_world,
+    )
+    moving_reg_data, moving_sample_valid = _sample_bilinear(
+        moving_band,
+        source_rows,
+        source_cols,
+        fill_value=moving_nodata_value if moving_nodata_value is not None else out_nodata,
+    )
+    sampled_mask, mask_valid = _sample_bilinear(
+        moving_valid,
+        source_rows,
+        source_cols,
+        fill_value=0.0,
+    )
+    moving_valid_for_registration = moving_sample_valid & mask_valid & (sampled_mask > 0.0)
+    return moving_reg_data, moving_valid_for_registration
+
+
 def _estimate_chunk_correspondences(
     *,
     chunk_id: str,
@@ -406,6 +482,7 @@ def _estimate_chunk_correspondences(
     enforce_mutual_valid_mask: bool,
     use_edge_proxies: bool,
     solve_transform,
+    current_transform: GlobalRigidTransform,
     core_solve_window: Window,
     chunk_solve_window: Window,
 ) -> Optional[tuple[np.ndarray, np.ndarray]]:
@@ -425,34 +502,14 @@ def _estimate_chunk_correspondences(
         max_width=int(fixed_window.width),
         max_height=int(fixed_window.height),
     )
-    moving_chunk_abs = _to_int_window(
-        from_bounds(
-            left=chunk_bounds[0],
-            bottom=chunk_bounds[1],
-            right=chunk_bounds[2],
-            top=chunk_bounds[3],
-            transform=moving_src.transform,
-        ),
-        max_width=moving_src.width,
-        max_height=moving_src.height,
-    )
-    if (
-        fixed_chunk_rel.width <= 0
-        or fixed_chunk_rel.height <= 0
-        or moving_chunk_abs.width <= 0
-        or moving_chunk_abs.height <= 0
-    ):
+    if fixed_chunk_rel.width <= 0 or fixed_chunk_rel.height <= 0:
         return None
 
     fixed_chunk_abs = _window_in_parent(fixed_window, fixed_chunk_rel)
     fixed_band = fixed_src.read(fixed_band_1based, window=fixed_chunk_abs)
-    moving_band = moving_src.read(moving_band_1based, window=moving_chunk_abs)
     fixed_valid = fixed_src.read_masks(fixed_band_1based, window=fixed_chunk_abs) > 0
-    moving_valid = moving_src.read_masks(moving_band_1based, window=moving_chunk_abs) > 0
     if fixed_nodata_value is not None:
         fixed_valid &= fixed_band != fixed_nodata_value
-    if moving_nodata_value is not None:
-        moving_valid &= moving_band != moving_nodata_value
 
     solve_height = int(chunk_solve_window.height)
     solve_width = int(chunk_solve_window.width)
@@ -461,13 +518,7 @@ def _estimate_chunk_correspondences(
         fixed_nodata_value if fixed_nodata_value is not None else out_nodata,
         dtype=np.float32,
     )
-    moving_reg_data = np.full(
-        (solve_height, solve_width),
-        moving_nodata_value if moving_nodata_value is not None else out_nodata,
-        dtype=np.float32,
-    )
     fixed_valid_reprojected = np.zeros((solve_height, solve_width), dtype=np.uint8)
-    moving_valid_reprojected = np.zeros((solve_height, solve_width), dtype=np.uint8)
 
     reproject(
         source=fixed_band.astype(np.float32),
@@ -481,17 +532,6 @@ def _estimate_chunk_correspondences(
         resampling=Resampling.nearest,
     )
     reproject(
-        source=moving_band.astype(np.float32),
-        destination=moving_reg_data,
-        src_transform=moving_src.window_transform(moving_chunk_abs),
-        src_crs=moving_src.crs,
-        dst_transform=chunk_solve_transform,
-        dst_crs=fixed_src.crs,
-        src_nodata=moving_nodata_value,
-        dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
-        resampling=Resampling.nearest,
-    )
-    reproject(
         source=fixed_valid.astype(np.uint8),
         destination=fixed_valid_reprojected,
         src_transform=fixed_src.window_transform(fixed_chunk_abs),
@@ -502,20 +542,67 @@ def _estimate_chunk_correspondences(
         dst_nodata=0,
         resampling=Resampling.nearest,
     )
-    reproject(
-        source=moving_valid.astype(np.uint8),
-        destination=moving_valid_reprojected,
-        src_transform=moving_src.window_transform(moving_chunk_abs),
-        src_crs=moving_src.crs,
-        dst_transform=chunk_solve_transform,
-        dst_crs=fixed_src.crs,
-        src_nodata=0,
-        dst_nodata=0,
-        resampling=Resampling.nearest,
-    )
+
+    if _is_identity_transform(current_transform):
+        moving_chunk_abs = _to_int_window(
+            from_bounds(
+                left=chunk_bounds[0],
+                bottom=chunk_bounds[1],
+                right=chunk_bounds[2],
+                top=chunk_bounds[3],
+                transform=moving_src.transform,
+            ),
+            max_width=moving_src.width,
+            max_height=moving_src.height,
+        )
+        if moving_chunk_abs.width <= 0 or moving_chunk_abs.height <= 0:
+            return None
+        moving_band = moving_src.read(moving_band_1based, window=moving_chunk_abs)
+        moving_valid = moving_src.read_masks(moving_band_1based, window=moving_chunk_abs) > 0
+        if moving_nodata_value is not None:
+            moving_valid &= moving_band != moving_nodata_value
+        moving_reg_data = np.full(
+            (solve_height, solve_width),
+            moving_nodata_value if moving_nodata_value is not None else out_nodata,
+            dtype=np.float32,
+        )
+        moving_valid_reprojected = np.zeros((solve_height, solve_width), dtype=np.uint8)
+        reproject(
+            source=moving_band.astype(np.float32),
+            destination=moving_reg_data,
+            src_transform=moving_src.window_transform(moving_chunk_abs),
+            src_crs=moving_src.crs,
+            dst_transform=chunk_solve_transform,
+            dst_crs=fixed_src.crs,
+            src_nodata=moving_nodata_value,
+            dst_nodata=moving_nodata_value if moving_nodata_value is not None else out_nodata,
+            resampling=Resampling.nearest,
+        )
+        reproject(
+            source=moving_valid.astype(np.uint8),
+            destination=moving_valid_reprojected,
+            src_transform=moving_src.window_transform(moving_chunk_abs),
+            src_crs=moving_src.crs,
+            dst_transform=chunk_solve_transform,
+            dst_crs=fixed_src.crs,
+            src_nodata=0,
+            dst_nodata=0,
+            resampling=Resampling.nearest,
+        )
+        moving_valid_for_registration = moving_valid_reprojected > 0
+    else:
+        moving_reg_data, moving_valid_for_registration = _sample_moving_band_on_solve_grid(
+            moving_src=moving_src,
+            moving_band_1based=moving_band_1based,
+            moving_nodata_value=moving_nodata_value,
+            out_nodata=out_nodata,
+            chunk_solve_transform=chunk_solve_transform,
+            solve_width=solve_width,
+            solve_height=solve_height,
+            current_transform=current_transform,
+        )
 
     fixed_valid_for_registration = fixed_valid_reprojected > 0
-    moving_valid_for_registration = moving_valid_reprojected > 0
     fixed_mask_for_elastix = fixed_valid_for_registration.astype(np.uint8)
     moving_mask_for_elastix = moving_valid_for_registration.astype(np.uint8)
     if use_edge_proxies:
@@ -602,7 +689,8 @@ def _estimate_chunk_correspondences(
         source_points_local[:, 0].reshape(anchor_cols.shape),
     )
     target_points = np.column_stack([target_x.ravel(), target_y.ravel()])
-    source_points = np.column_stack([source_x.ravel(), source_y.ravel()])
+    residual_source_points = np.column_stack([source_x.ravel(), source_y.ravel()])
+    source_points = _transform_points(current_transform, residual_source_points)
     if not np.isfinite(source_points).all():
         return None
     return target_points, source_points
@@ -634,6 +722,7 @@ def align_image_pair(
     use_edge_proxies: bool = True,
     split_factor: int = 2,
     solve_resolution: Optional[float] = None,
+    solve_resolutions: Optional[Sequence[Optional[float]]] = None,
 ) -> AlignmentResult:
     if band_index < 0:
         raise ValueError("band_index must be >= 0 (0-based).")
@@ -651,6 +740,17 @@ def align_image_pair(
         raise ValueError("split_factor must be > 0 for the chunked alignment path.")
     if solve_resolution is not None and solve_resolution <= 0:
         raise ValueError("solve_resolution must be > 0 when provided.")
+    if solve_resolution is not None and solve_resolutions is not None:
+        raise ValueError("Provide only one of solve_resolution or solve_resolutions.")
+    if solve_resolutions is not None:
+        if len(solve_resolutions) == 0:
+            raise ValueError("solve_resolutions must contain at least one entry.")
+        for resolution in solve_resolutions:
+            if resolution is not None and resolution <= 0:
+                raise ValueError("solve_resolutions entries must be > 0 or None.")
+        solve_resolution_sequence = list(solve_resolutions)
+    else:
+        solve_resolution_sequence = [solve_resolution]
     temp_ctx = None
     work_dir: str
     if keep_temp_dir:
@@ -725,67 +825,74 @@ def align_image_pair(
             raise ValueError("No overlap between reference-raster ROI and source-raster grid.")
         moving_window_transform = moving_src.window_transform(moving_window)
 
-        solve_width, solve_height, solve_transform = _resolve_solve_grid(
-            base_transform=fixed_window_transform,
-            base_width=int(fixed_window.width),
-            base_height=int(fixed_window.height),
-            solve_resolution=solve_resolution,
-        )
+        global_transform = _identity_transform()
+        solve_width = solve_height = 0
+        solve_transform = fixed_window_transform
+        for pass_idx, pass_solve_resolution in enumerate(solve_resolution_sequence):
+            solve_width, solve_height, solve_transform = _resolve_solve_grid(
+                base_transform=fixed_window_transform,
+                base_width=int(fixed_window.width),
+                base_height=int(fixed_window.height),
+                solve_resolution=pass_solve_resolution,
+            )
 
-        solve_rows, solve_cols = _chunk_grid_shape(split_factor, solve_width, solve_height)
-        solve_row_splits = _split_positions(solve_height, solve_rows)
-        solve_col_splits = _split_positions(solve_width, solve_cols)
+            solve_rows, solve_cols = _chunk_grid_shape(split_factor, solve_width, solve_height)
+            solve_row_splits = _split_positions(solve_height, solve_rows)
+            solve_col_splits = _split_positions(solve_width, solve_cols)
 
-        target_points: list[np.ndarray] = []
-        source_points: list[np.ndarray] = []
-        for row_idx in range(solve_rows):
-            for col_idx in range(solve_cols):
-                core_solve_window = Window(
-                    col_off=solve_col_splits[col_idx],
-                    row_off=solve_row_splits[row_idx],
-                    width=solve_col_splits[col_idx + 1] - solve_col_splits[col_idx],
-                    height=solve_row_splits[row_idx + 1] - solve_row_splits[row_idx],
-                )
-                if core_solve_window.width <= 0 or core_solve_window.height <= 0:
-                    continue
-                chunk_solve_window = _expand_window(
-                    core_solve_window,
-                    CHUNK_OVERLAP_PX,
-                    solve_width,
-                    solve_height,
-                )
-                chunk_pairs = _estimate_chunk_correspondences(
-                    chunk_id=f"chunk_r{row_idx}_c{col_idx}",
-                    fixed_src=fixed_src,
-                    moving_src=moving_src,
-                    fixed_window=fixed_window,
-                    fixed_window_transform=fixed_window_transform,
-                    moving_band_1based=moving_band_1based,
-                    fixed_band_1based=fixed_band_1based,
-                    moving_nodata_value=moving_nodata_value,
-                    fixed_nodata_value=fixed_nodata_value,
-                    out_nodata=out_nodata,
-                    min_valid_fraction=min_valid_fraction,
-                    work_dir=work_dir,
-                    log_to_console=log_to_console,
-                    enforce_mutual_valid_mask=enforce_mutual_valid_mask,
-                    use_edge_proxies=use_edge_proxies,
-                    solve_transform=solve_transform,
-                    core_solve_window=core_solve_window,
-                    chunk_solve_window=chunk_solve_window,
-                )
-                if chunk_pairs is None:
-                    continue
-                target_chunk_points, source_chunk_points = chunk_pairs
-                target_points.append(target_chunk_points)
-                source_points.append(source_chunk_points)
+            target_points: list[np.ndarray] = []
+            source_points: list[np.ndarray] = []
+            for row_idx in range(solve_rows):
+                for col_idx in range(solve_cols):
+                    core_solve_window = Window(
+                        col_off=solve_col_splits[col_idx],
+                        row_off=solve_row_splits[row_idx],
+                        width=solve_col_splits[col_idx + 1] - solve_col_splits[col_idx],
+                        height=solve_row_splits[row_idx + 1] - solve_row_splits[row_idx],
+                    )
+                    if core_solve_window.width <= 0 or core_solve_window.height <= 0:
+                        continue
+                    chunk_solve_window = _expand_window(
+                        core_solve_window,
+                        CHUNK_OVERLAP_PX,
+                        solve_width,
+                        solve_height,
+                    )
+                    chunk_pairs = _estimate_chunk_correspondences(
+                        chunk_id=f"pass{pass_idx}_chunk_r{row_idx}_c{col_idx}",
+                        fixed_src=fixed_src,
+                        moving_src=moving_src,
+                        fixed_window=fixed_window,
+                        fixed_window_transform=fixed_window_transform,
+                        moving_band_1based=moving_band_1based,
+                        fixed_band_1based=fixed_band_1based,
+                        moving_nodata_value=moving_nodata_value,
+                        fixed_nodata_value=fixed_nodata_value,
+                        out_nodata=out_nodata,
+                        min_valid_fraction=min_valid_fraction,
+                        work_dir=work_dir,
+                        log_to_console=log_to_console,
+                        enforce_mutual_valid_mask=enforce_mutual_valid_mask,
+                        use_edge_proxies=use_edge_proxies,
+                        solve_transform=solve_transform,
+                        current_transform=global_transform,
+                        core_solve_window=core_solve_window,
+                        chunk_solve_window=chunk_solve_window,
+                    )
+                    if chunk_pairs is None:
+                        continue
+                    target_chunk_points, source_chunk_points = chunk_pairs
+                    target_points.append(target_chunk_points)
+                    source_points.append(source_chunk_points)
 
-        if not target_points:
-            raise ValueError("No chunk produced a valid local solve. Try a lower split_factor or coarser solve_resolution.")
-        global_transform = _fit_global_rigid_transform(
-            np.vstack(target_points),
-            np.vstack(source_points),
-        )
+            if not target_points:
+                raise ValueError(
+                    "No chunk produced a valid local solve. Try a lower split_factor or coarser solve_resolution."
+                )
+            global_transform = _fit_global_rigid_transform(
+                np.vstack(target_points),
+                np.vstack(source_points),
+            )
 
         os.makedirs(os.path.dirname(output_image_path) or ".", exist_ok=True)
         temp_output_image_path = os.path.join(work_dir, os.path.basename(output_image_path))

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -80,17 +80,20 @@ align-image-pair \
 
 Coregix estimates the transform on a solve grid derived from the reference raster. By default, the solve grid uses the reference raster's pixel spacing over the registration region.
 
-`--solve-resolution` can be used to estimate the transform on a coarser grid, expressed in raster CRS units:
+`--solve-resolutions` can be used to run one or more solves from coarse to fine, with each pixel size expressed in raster CRS units. Use `0` for the native/reference solve resolution:
 
 ```bash
 align-image-pair \
   --moving-image source.tif \
   --fixed-image reference.tif \
   --output-image aligned.tif \
-  --solve-resolution 2.0
+  --split-factor 2 \
+  --solve-resolutions 8,4,0
 ```
 
-During solve-grid preparation, source and reference registration bands and masks are resampled onto the solve grid with nearest-neighbor resampling. This preserves mask classes and avoids creating interpolated values in the registration inputs.
+Each pass refines the previous transform, and the final output is resampled once from the original source raster. During solve-grid preparation, source and reference registration bands and masks are resampled onto the solve grid with nearest-neighbor resampling. This preserves mask classes and avoids creating interpolated values in the registration inputs.
+
+`--solve-resolution` is deprecated and remains available only for single-pass runs. Prefer `--solve-resolutions`, even for one solve, for example `--solve-resolutions 4`.
 
 ## Transform Application and Resampling
 

--- a/docs/usage/large-rasters.md
+++ b/docs/usage/large-rasters.md
@@ -42,11 +42,11 @@ Use the smallest split factor that keeps processing stable.
 
 Higher values create more chunks and more overhead. They can also fail if individual chunks do not contain enough valid, informative overlap for registration.
 
-## Coarser Registration Solve
+## Coarse-to-fine Registration Solve
 
-`--solve-resolution` runs the registration solve on a coarser grid while still writing the final output on the requested output grid. The value is expressed in raster CRS units.
+`--solve-resolutions` runs one or more registration solves from coarse to fine while still writing the final output on the requested output grid. Values are expressed in raster CRS units. Use `0` for the native/reference solve resolution.
 
-For a projected CRS in meters, `--solve-resolution 2.0` uses an approximate 2-meter solve grid:
+For a projected CRS in meters, `--solve-resolutions 8,4,0.5` first solves on an approximate 8-meter grid, refines on a 4-meter grid, then refines again on a 0.5-meter grid:
 
 ```bash
 align-image-pair \
@@ -54,23 +54,23 @@ align-image-pair \
   --fixed-image reference.tif \
   --output-image aligned_large.tif \
   --split-factor 2 \
-  --solve-resolution 2.0
+  --solve-resolutions 8,4,0.5
 ```
 
-This can reduce registration cost for high-resolution rasters. Use a solve resolution that preserves the spatial structure needed for alignment.
+Each pass refines the previous transform, and the final raster is sampled once from the original source image. This can make large-offset alignments more stable without stacking multiple resampling steps.
 
-## Coarse-to-fine Alignment
+`--solve-resolution` is deprecated and remains available only for single-pass compatibility. Prefer `--solve-resolutions`, even for one solve, for example `--solve-resolutions 2.0`.
 
-Area-based registration works best when the source and reference rasters are already close. For difficult pairs, a coarse-to-fine approach can be more reliable than a single full-resolution run.
+## Manual Coarse-to-fine Alignment
 
-One practical manual pattern is:
+The in-memory `--solve-resolutions` workflow should be the default coarse-to-fine approach. A manual two-stage pattern can still be useful when you want to inspect or keep the intermediate coarse result:
 
 1. create lower-resolution source and reference products
 2. coregister the lower-resolution source to the lower-resolution reference
 3. use the coarse result to create an intermediate full-resolution source that is closer to the reference
 4. run Coregix again at full resolution to refine the alignment
 
-The first pass handles the larger residual offset on a simpler image pair. The second pass starts from a closer alignment, giving the area-based registration a better chance of converging on the fine-scale correction. Coregix does not currently accept an initial transform directly; this is a two-stage processing strategy using the output from the first run as input to the second.
+The first pass handles the larger residual offset on a simpler image pair. The second pass starts from a closer alignment, giving the area-based registration a better chance of converging on the fine-scale correction.
 
 ## Grid and Metadata Behavior
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,23 @@ def test_align_parser_boolean_flags_can_be_disabled() -> None:
     assert args.enforce_mutual_valid_mask is False
 
 
+def test_align_parser_accepts_coarse_to_fine_solve_resolutions() -> None:
+    args = align_cli.build_parser().parse_args(
+        [
+            "--moving-image",
+            "source.tif",
+            "--fixed-image",
+            "reference.tif",
+            "--output-image",
+            "aligned.tif",
+            "--solve-resolutions",
+            "8,4,0",
+        ]
+    )
+
+    assert args.solve_resolutions == [8.0, 4.0, None]
+
+
 def test_align_cli_forwards_arguments_and_prints_json(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -91,8 +108,8 @@ def test_align_cli_forwards_arguments_and_prints_json(
             "2",
             "--split-factor",
             "2",
-            "--solve-resolution",
-            "4",
+            "--solve-resolutions",
+            "8,4,0",
             "--trim-edge-invalid",
             "--edge-trim-depth",
             "3",
@@ -110,7 +127,8 @@ def test_align_cli_forwards_arguments_and_prints_json(
     assert captured_kwargs["moving_band_index"] == 1
     assert captured_kwargs["fixed_band_index"] == 2
     assert captured_kwargs["split_factor"] == 2
-    assert captured_kwargs["solve_resolution"] == 4
+    assert captured_kwargs["solve_resolution"] is None
+    assert captured_kwargs["solve_resolutions"] == [8.0, 4.0, None]
     assert captured_kwargs["trim_edge_invalid"] is True
     assert captured_kwargs["edge_trim_depth"] == 3
     assert captured_kwargs["edge_trim_invalid_below"] == -3000


### PR DESCRIPTION
## Summary

Adds in-memory coarse-to-fine registration via solve_resolutions / --solve-resolutions.

This lets users run multiple solve passes, for example 8,4,0.5, where each pass refines the previous transform and the final raster is written once from the original moving image. The existing solve_resolution / --solve-resolution single-pass option remains supported but is now documented as deprecated.

## Changes
  - Added CLI option --solve-resolutions, e.g. --solve-resolutions 8,4,0.5
  - Added Python API argument solve_resolutions
  - Implemented multi-pass chunked alignment in the large-raster path
  - Preserved single-pass solve_resolution behavior for compatibility
  - Marked --solve-resolution / solve_resolution as deprecated in CLI help and docs
  - Updated README and large-raster/concepts docs
  - Added CLI tests for parsing and forwarding --solve-resolutions

## Validation

  - conda run -n coregix python -m compileall coregix tests
  - Confirmed CLI help shows --solve-resolution as deprecated

## Notes

  --solve-resolutions requires chunked alignment for multi-pass runs. Use 0 in the CLI value list to mean native/reference resolution, e.g. --solve-resolutions 8,4,0